### PR TITLE
Make `rotate-windows` aware of dedicated windows.

### DIFF
--- a/defuns/buffer-defuns.el
+++ b/defuns/buffer-defuns.el
@@ -59,30 +59,34 @@
           (select-window first-win)
           (if this-win-2nd (other-window 1))))))
 
-(defun rotate-windows ()
-  "Rotate your windows"
-  (interactive)
-  (cond ((not (> (count-windows)1))
-         (message "You can't rotate a single window!"))
-        (t
-         (setq i 1)
-         (setq numWindows (count-windows))
-         (while  (< i numWindows)
-           (let* (
-                  (w1 (elt (window-list) i))
-                  (w2 (elt (window-list) (+ (% i numWindows) 1)))
+(defun rotate-windows (count)
+  "Rotate your windows.
+Dedicated windows are left untouched. Giving a negative prefix
+argument makes the windows rotate backwards."
+  (interactive "p")
+  (let* ((non-dedicated-windows (remove-if 'window-dedicated-p (window-list)))
+         (num-windows (length non-dedicated-windows))
+         (i 0)
+         (step (+ num-windows count)))
+    (cond ((not (> num-windows 1))
+           (message "You can't rotate a single window!"))
+          (t
+           (dotimes (counter (- num-windows 1))
+             (let* ((next-i (% (+ step i) num-windows))
 
-                  (b1 (window-buffer w1))
-                  (b2 (window-buffer w2))
+                    (w1 (elt non-dedicated-windows i))
+                    (w2 (elt non-dedicated-windows next-i))
 
-                  (s1 (window-start w1))
-                  (s2 (window-start w2))
-                  )
-             (set-window-buffer w1  b2)
-             (set-window-buffer w2 b1)
-             (set-window-start w1 s2)
-             (set-window-start w2 s1)
-             (setq i (1+ i)))))))
+                    (b1 (window-buffer w1))
+                    (b2 (window-buffer w2))
+
+                    (s1 (window-start w1))
+                    (s2 (window-start w2)))
+               (set-window-buffer w1 b2)
+               (set-window-buffer w2 b1)
+               (set-window-start w1 s2)
+               (set-window-start w2 s1)
+               (setq i next-i)))))))
 
 (defun ido-imenu ()
   "Update the imenu index and then use ido to select a symbol to navigate to.


### PR DESCRIPTION
Hello, and thanks for your new "What the .emacs.d!?" blog, in which I learned tons of interesting stuff.

I was very interested by your `rotate-windows` function, but it didn't always work in my case since I tend to use dedicated windows (for example for compilation or help buffers).
In case you're interested, here is a version which leaves dedicated windows untouched.

Thanks again,
   François
