### PR TITLE
The macro kbd only works with string constants, not with variables.

### DIFF
--- a/setup-js2-mode.el
+++ b/setup-js2-mode.el
@@ -30,9 +30,9 @@
 ;; Set up wrapping of pairs, with the possiblity of semicolons thrown into the mix
 
 (defun js2r--setup-wrapping-pair (open close)
-  (define-key js2-mode-map (kbd open) (λ (js2r--self-insert-wrapping open close)))
+  (define-key js2-mode-map (read-kbd-macro open) (λ (js2r--self-insert-wrapping open close)))
   (unless (s-equals? open close)
-    (define-key js2-mode-map (kbd close) (λ (js2r--self-insert-closing open close)))))
+    (define-key js2-mode-map (read-kbd-macro close) (λ (js2r--self-insert-closing open close)))))
 
 (define-key js2-mode-map (kbd ";")
   (λ (if (looking-at ";")


### PR DESCRIPTION
`(kbd open)` generates an error: `"wrong-type-argument integer-or-marker-p open"`. 
As I understand it, `kbd` is a macro and should be called with string constants. The function `read-kbd-macro`, which is what the `kbd` macro calls, can be used instead. See also http://stackoverflow.com/q/7549628/386327 .
