### PR TITLE
Try this please

### DIFF
--- a/init.el
+++ b/init.el
@@ -122,7 +122,7 @@
 (eval-after-load 'grep '(require 'setup-rgrep))
 (eval-after-load 'shell '(require 'setup-shell))
 (require 'setup-hippie)
-(require 'setup-yasnippet)
+;;(require 'setup-yasnippet)
 (require 'setup-perspective)
 (require 'setup-ffip)
 (require 'setup-html-mode)
@@ -148,7 +148,9 @@
   (add-hook it 'turn-on-smartparens-mode))
 
 ;; Language specific setup files
+; (require 'yasnippet) ; Requiring before js2-mode works
 (eval-after-load 'js2-mode '(require 'setup-js2-mode))
+(require 'yasnippet) ; After js-mode fails
 (eval-after-load 'ruby-mode '(require 'setup-ruby-mode))
 (eval-after-load 'clojure-mode '(require 'setup-clojure-mode))
 (eval-after-load 'markdown-mode '(require 'setup-markdown-mode))


### PR DESCRIPTION
Move yasnippet to after js2-mode.

See if you get failures like:
"Don't know how to make a localized variable an alias"
defvaralias(yas/fallback-behavior yas-fallback-behavior)

If I (require 'yasnippet) before js2-mode it works.
After js2-mode I get the error mentioned above.

I'm wondering whether its worth pursuing this as a bug, or else just live with the workaround.
The only thing I can find via google searches is https://github.com/capitaomorte/yasnippet/issues/528.