### PR TITLE
Fix flycheck-pos-tip-error-messages returning void

### DIFF
--- a/settings/setup-flycheck.el
+++ b/settings/setup-flycheck.el
@@ -1,4 +1,5 @@
 (require 'flycheck)
+(require 'flycheck-pos-tip)
 
 (defun magnars/adjust-flycheck-automatic-syntax-eagerness ()
   "Adjust how often we check for errors based on if there are any.


### PR DESCRIPTION
Well first of all I have to thank you for sharing `.emacs.d`. I'm consuming it partly now. 

However I couldn't get your flycheck setup to work properly when I was in `some mode` and on a code error the flycheck position tip was not shown and returned `function void flycheck-pos-tip-error-messages`.

For my own `.emacs.d` I solved it with a `(require 'flycheck-pos-tip)` ~ but I'm not sure if its `the solution`. Take it or leave it :) pelle