### PR TITLE
Restore loading setup-flycheck

### DIFF
--- a/init.el
+++ b/init.el
@@ -239,6 +239,7 @@
 (autoload 'skewer-start "setup-skewer" nil t)
 (autoload 'skewer-demo "setup-skewer" nil t)
 (autoload 'auto-complete-mode "auto-complete" nil t)
+(eval-after-load 'flycheck '(require 'setup-flycheck))
 
 ;; Map files to modes
 (require 'mode-mappings)


### PR DESCRIPTION
Greetings! Whilst once again scavenging for parts in this fine .emacs.d (which has served as my template for years now) I discovered that setup-flycheck is not being loaded. It seems to have been removed accidentally. I thought I'd re-add the one missing line.

Details in my commit message: "Loading setup-flycheck was originally added in commit https://github.com/magnars/.emacs.d/commit/0802ba424dd9a1b0cfb6e7d02fd64a0d882be6d0 but removed "for now" in commit https://github.com/magnars/.emacs.d/commit/f8c1baa7fe31224125824e6327d200581e9b8052."