### PR TITLE
README: Update Emacs installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ that are best handled by the package manager.
 
 I use Cocoa Emacs, installed like this:
 
-    brew cask install emacs
+    brew install --cask emacs
 
 ## Tips for using these emacs settings
 


### PR DESCRIPTION
With Homebrew 4.4.1, `brew cask install` has been replaced with `brew install --cask emacs`.

Old README instructions give an error:

```
$ brew --version
Homebrew 4.4.1
$ brew cask install emacs
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```